### PR TITLE
Exclude 'gnome-classic-session-xsession' package for Fedora 40

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28,5 +28,15 @@
                 "htop"
             ]
         }
+    },
+    "40": {
+        "include": {
+            "all": []
+        },
+        "exclude": {
+            "all": [
+                "gnome-classic-session-xsession"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Problem: package gnome-classic-session-xsession-46.0-1.fc40.noarch from @System requires gnome-classic-session = 46.0-1.fc40, but none of the providers can be installed